### PR TITLE
Create a GMX grammar

### DIFF
--- a/grammars/gml.cson
+++ b/grammars/gml.cson
@@ -1,8 +1,7 @@
 'scopeName': 'source.gml'
 'comment': 'GML Syntax: version 0.1'
 'fileTypes': [
-  'gml',
-  'gmx'
+  'gml'
 ]
 'firstLineMatch': '\\A#!.*?\\bgml\\b'
 'name': 'GML'

--- a/grammars/gmx.cson
+++ b/grammars/gmx.cson
@@ -1,0 +1,27 @@
+# Partially copied from https://github.com/atom/language-xml/blob/master/grammars/xml.cson
+'scopeName': 'source.gmx'
+'comment': 'GMX Syntax: version 0.1'
+'fileTypes': [
+  'gmx'
+]
+'patterns': [
+  {
+    'contentName': 'source.gml.embedded'
+    'begin':'(?i)(<)(string)(>)'
+    'end': '(?i)(<\/)(string)(>)'
+    'captures':
+      '1':
+        'name': 'punctuation.definition.tag.xml'
+      '2':
+        'name': 'entity.name.tag.xml'
+      '3':
+        'name': 'punctuation.definition.tag.xml'
+    'patterns': [
+      {'include': 'source.gml'}
+    ]
+  }
+  {
+    'name': 'text.xml.gmx'
+    'include': 'text.xml'
+  }
+]


### PR DESCRIPTION
GMX is not a filetype for a GML source file - it is an xml file for objects in GameMaker - see https://docs.yoyogames.com/source/dadiospice/001_advanced%20use/008_exporting%20and%20importing%20resources.html
